### PR TITLE
Fix text wrapping in Markdown editor right pane

### DIFF
--- a/src/renderer/components/MarkdownEditor.tsx
+++ b/src/renderer/components/MarkdownEditor.tsx
@@ -144,6 +144,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         markdownKeymap,
         EditorView.updateListener.of(handleChange),
         EditorView.editable.of(!readOnly),
+        EditorView.lineWrapping,
         EditorView.theme({
           '&': {
             height: '100%',
@@ -155,6 +156,11 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           },
           '.cm-content': {
             padding: '16px',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          },
+          '.cm-line': {
+            wordBreak: 'break-word',
           },
           '.cm-gutters': {
             backgroundColor: '#f8fafc',


### PR DESCRIPTION
## Summary
- OCRテキストが右ペインの幅に合わせて自動的に折り返されるように修正
- CodeMirror の `EditorView.lineWrapping` 拡張を追加
- CSS プロパティ (`whiteSpace: 'pre-wrap'`, `wordBreak: 'break-word'`) を追加

## Changes
- `src/renderer/components/MarkdownEditor.tsx`
  - `EditorView.lineWrapping` を extensions 配列に追加
  - `.cm-content` に折り返し用CSSプロパティを追加
  - `.cm-line` に `wordBreak: 'break-word'` を追加

## Test plan
- [x] ビルドが成功することを確認 (`npm run build`)
- [x] 全テスト（186件）がパスすることを確認 (`npm test`)
- [x] 長い一行テキスト（200文字以上）が折り返されることを確認
- [x] 日本語テキストが適切に折り返されることを確認
- [x] スプリッターでペイン幅を変更した際に再折り返しされることを確認
- [x] ウィンドウリサイズ時に再折り返しされることを確認

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)